### PR TITLE
Union as range without type

### DIFF
--- a/.linkmllint.yaml
+++ b/.linkmllint.yaml
@@ -1,0 +1,5 @@
+# Use all of the recommended rule and adjusts the standard_naming rule
+extends: recommended
+rules:
+  standard_naming:
+    permissible_values_upper_case: true

--- a/src/data/examples/invalid/IntermicrobialInteraction-pairwise-with-wrong-missing-data.yaml
+++ b/src/data/examples/invalid/IntermicrobialInteraction-pairwise-with-wrong-missing-data.yaml
@@ -1,0 +1,9 @@
+id: miiid:pairwise
+participants:
+  - Acidobacteria
+  - Gammaproteobacteria
+tax_id:
+  - NA
+  - 1236
+evidence_type: high throughput evidence used in automatic assertion
+reference: https://doi.org/10.1038/ismej.2011.119

--- a/src/data/examples/valid/IntermicrobialInteraction-pairwise-with-missing-data.yaml
+++ b/src/data/examples/valid/IntermicrobialInteraction-pairwise-with-missing-data.yaml
@@ -1,0 +1,9 @@
+id: miiid:pairwise
+participants:
+  - Acidobacteria
+  - Gammaproteobacteria
+tax_id:
+  - NOT_PROVIDED
+  - 1236
+evidence_type: high throughput evidence used in automatic assertion
+reference: https://doi.org/10.1038/ismej.2011.119

--- a/src/miiid_schema/schema/miiid_schema.yaml
+++ b/src/miiid_schema/schema/miiid_schema.yaml
@@ -78,7 +78,7 @@ slots:
   tax_id:
     required: true
     any_of:
-      - range: NCBITaxId
+      - range: int
       - range: MissingValue
     multivalued: true
     description: NCBI Taxonomy identifiers at the relevant taxonomic level.

--- a/src/miiid_schema/schema/miiid_schema.yaml
+++ b/src/miiid_schema/schema/miiid_schema.yaml
@@ -17,6 +17,7 @@ prefixes:
   EDAM_TOPIC: http://edamontology.org/topic_
   NCIT: http://purl.obolibrary.org/obo/NCIT_
   OBI: http://purl.obolibrary.org/obo/OBI_
+  GENEPIO: http://purl.obolibrary.org/obo/GENEPIO_
 default_prefix: miiid
 default_range: string
 
@@ -76,9 +77,12 @@ slots:
     description: Names of the microbial entities, with descriptions of any genetic manipulations performed.
   tax_id:
     required: true
-    range: NCBITaxId
+    any_of:
+      - range: NCBITaxId
+      - range: MissingValue
     multivalued: true
-    description: NCBI Taxonomy identifiers at the relevant taxonomic level. Novel taxa lacking identifiers are denoted by N/A.
+    description: NCBI Taxonomy identifiers at the relevant taxonomic level.
+    comments: For novel taxa lacking identifiers, please use the controlled vocabulary NOT_PROVIDED.
   evidence_type:
     required: true
     range: string
@@ -135,3 +139,26 @@ enums:
           meaning: OBI:0000659
           examples:
             - value: co-occurrences drawn from analyses of abundances obtained from in situ or in vivo sampling
+
+  MissingValue:
+    description: >-
+      List of missing values reporting terms according based on the International
+      Nucleotide Sequence Database Collaboration (INSDC )
+    permissible_values:
+      NOT_APPLICABLE:
+        description: >-
+          The information is inappropriate to report, this can indicate that the
+          standard itself fails to model or represent the information appropriately
+        meaning: GENEPIO:0001619
+      NOT_COLLECTED:
+        description: >-
+          The information of an expected format was not given because it has not been collected
+        meaning: GENEPIO:0001620
+      NOT_PROVIDED:
+        description: >-
+          The information of an expected format was not given, a value may be given at the later stage
+        meaning: GENEPIO:0001668
+      RESTRICTED_ACCESS:
+        description: >-
+          The information exists but can not be released openly because of privacy concerns
+        meaning: GENEPIO:0001810


### PR DESCRIPTION
follow up of #9 to fix the validation. Here the issue is that all data are valid

```bash
linkml-validate -s src/miiid_schema/schema/miiid_schema.yaml -C IntermicrobialInteraction\ \
   src/data/examples/valid/IntermicrobialInteraction-pairwise-with-missing-data.yaml
# None for valid data
linkml-validate -s src/miiid_schema/schema/miiid_schema.yaml -C IntermicrobialInteraction \
   src/data/examples/invalid/IntermicrobialInteraction-pairwise-with-wrong-missing-data.yaml
# None for invalid data as well
```

It turns out that the integers or enums are converted to strings:

```bash
linkml-convert -s src/miiid_schema/schema/miiid_schema.yaml -C IntermicrobialInteraction \
   src/data/examples/invalid/IntermicrobialInteraction-pairwise-with-wrong-missing-data.yaml
```
```json
{
  "id": "miiid:pairwise",
  "participants": [
    "Acidobacteria",
    "Gammaproteobacteria"
  ],
  "tax_id": [
    "NA",    # <----
    "1236" # <----
  ],
  "evidence_type": "high throughput evidence used in automatic assertion",
  "reference": "https://doi.org/10.1038/ismej.2011.119",
  "@type": "IntermicrobialInteraction"
}
```